### PR TITLE
docker-registry-ui: add support for ingress

### DIFF
--- a/charts/docker-registry-ui/.helmignore
+++ b/charts/docker-registry-ui/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/docker-registry-ui/README.md
+++ b/charts/docker-registry-ui/README.md
@@ -56,21 +56,21 @@ helm upgrade --install docker-registry-ui joxit/docker-registry-ui
 | `ui.nodeSelector` | `{}` | Optional YAML string to specify a nodeSelector config. |
 | `ui.tolerations` | `[]` | Optional YAML string to specify tolerations. |
 | `ui.affinity` | `{}` | This value defines the [affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for server pods. |
-| `ui.annotations` | `null` | Annotations to apply to the user interface deployment. |
-| `ui.additionalSpec` | `null` | Optional YAML string that will be appended to the deployment spec. |
+| `ui.annotations` | `{}` | Annotations to apply to the user interface deployment. |
+| `ui.additionalSpec` | `{}` | Optional YAML string that will be appended to the deployment spec. |
 | `ui.service.type` | `ClusterIP` | Type of service: `LoadBalancer`, `ClusterIP` or `NodePort`. If using `NodePort` service type, you must set the desired `nodePorts` setting below. |
 | `ui.service.port` | `80` | Ports that will be exposed on the service |
 | `ui.service.targetPort` | `80` | The port to listhen on the container. If under 1024, the user must be root |
 | `ui.service.nodePort` | `null` | If using a `NodePort` service type, you must specify the desired `nodePort` for each exposed port. |
-| `ui.service.annotations` | `null` | Annotations to apply to the user interface service. |
-| `ui.service.additionalSpec` | `null` | Optional YAML string that will be appended to the Service spec. |
+| `ui.service.annotations` | `{}` | Annotations to apply to the user interface service. |
+| `ui.service.additionalSpec` | `{}` | Optional YAML string that will be appended to the Service spec. |
 | `ui.ingress.enable` | `false` | Enable the ingress for the user interface. |
 | `ui.ingress.host` | `null` | Fully qualified domain name of a network host. |
 | `ui.ingress.path` | `/` | Path is matched against the path of an incoming request. |
 | `ui.ingress.pathType` | `Prefix` | Determines the interpretation of the Path matching, must be Prefix to serve assets. |
 | `ui.ingress.ingressClassName` | `nginx` | The name of an IngressClass cluster resource. |
-| `ui.ingress.tls` | `null` | Optional YAML tls configuration. |
-| `ui.ingress.annotations` | `null` | Annotations to apply to the user interface ingress. |
+| `ui.ingress.tls` | `[]` | Optional YAML tls configuration. |
+| `ui.ingress.annotations` | `{}` | Annotations to apply to the user interface ingress. |
 
 ### Registry Server
 
@@ -85,18 +85,18 @@ helm upgrade --install docker-registry-ui joxit/docker-registry-ui
 | `registry.nodeSelector` | `{}` | Optional YAML string to specify a nodeSelector config. |
 | `registry.tolerations` | `[]` | Optional YAML string to specify tolerations. |
 | `registry.affinity` | `{}` | This value defines the [affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for server pods. |
-| `registry.annotations` | `null` | Annotations to apply to the registry server deployment. |
-| `registry.additionalSpec` | `null` | Optional YAML string that will be appended to the deployment spec. |
+| `registry.annotations` | `{}` | Annotations to apply to the registry server deployment. |
+| `registry.additionalSpec` | `{}` | Optional YAML string that will be appended to the deployment spec. |
 | `registry.service.type` | `ClusterIP` | Type of service: `LoadBalancer`, `ClusterIP` or `NodePort`. If using `NodePort` service type, you must set the desired `nodePorts` setting below. |
 | `registry.service.port` | `5000` | Ports that will be exposed on the service |
 | `registry.service.targetPort` | `5000` | The port to listhen on the container. |
 | `registry.service.nodePort` | `null` | If using a `NodePort` service type, you must specify the desired `nodePort` for each exposed port. |
-| `registry.service.annotations` | `null` | Annotations to apply to the user interface service. |
-| `registry.service.additionalSpec` | `null` | Optional YAML string that will be appended to the Service spec. |
+| `registry.service.annotations` | `{}` | Annotations to apply to the user interface service. |
+| `registry.service.additionalSpec` | `{}` | Optional YAML string that will be appended to the Service spec. |
 | `registry.ingress.enable` | `false` | Enable the ingress for the registry server. |
 | `registry.ingress.host` | `null` | Fully qualified domain name of a network host. |
 | `registry.ingress.path` | `/v2/` | Path is matched against the path of an incoming request. |
 | `registry.ingress.pathType` | `Prefix` | Determines the interpretation of the Path matching, must be Prefix to serve assets. |
 | `registry.ingress.ingressClassName` | `nginx` | The name of an IngressClass cluster resource. |
-| `registry.ingress.tls` | `null` | Optional YAML tls configuration. |
-| `registry.ingress.annotations` | `null` | Annotations to apply to the registry server ingress. |
+| `registry.ingress.tls` | `[]` | Optional YAML tls configuration. |
+| `registry.ingress.annotations` | `{}` | Annotations to apply to the registry server ingress. |

--- a/charts/docker-registry-ui/README.md
+++ b/charts/docker-registry-ui/README.md
@@ -93,3 +93,10 @@ helm upgrade --install docker-registry-ui joxit/docker-registry-ui
 | `registry.service.nodePort` | `null` | If using a `NodePort` service type, you must specify the desired `nodePort` for each exposed port. |
 | `registry.service.annotations` | `null` | Annotations to apply to the user interface service. |
 | `registry.service.additionalSpec` | `null` | Optional YAML string that will be appended to the Service spec. |
+| `registry.ingress.enable` | `false` | Enable the ingress for the registry server. |
+| `registry.ingress.host` | `null` | Fully qualified domain name of a network host. |
+| `registry.ingress.path` | `/v2/` | Path is matched against the path of an incoming request. |
+| `registry.ingress.pathType` | `Prefix` | Determines the interpretation of the Path matching, must be Prefix to serve assets. |
+| `registry.ingress.ingressClassName` | `nginx` | The name of an IngressClass cluster resource. |
+| `registry.ingress.tls` | `null` | Optional YAML tls configuration. |
+| `registry.ingress.annotations` | `null` | Annotations to apply to the registry server ingress. |

--- a/charts/docker-registry-ui/README.md
+++ b/charts/docker-registry-ui/README.md
@@ -64,6 +64,13 @@ helm upgrade --install docker-registry-ui joxit/docker-registry-ui
 | `ui.service.nodePort` | `null` | If using a `NodePort` service type, you must specify the desired `nodePort` for each exposed port. |
 | `ui.service.annotations` | `null` | Annotations to apply to the user interface service. |
 | `ui.service.additionalSpec` | `null` | Optional YAML string that will be appended to the Service spec. |
+| `ui.ingress.enable` | `false` | Enable the ingress for the user interface. |
+| `ui.ingress.host` | `null` | Fully qualified domain name of a network host. |
+| `ui.ingress.path` | `/` | Path is matched against the path of an incoming request. |
+| `ui.ingress.pathType` | `Prefix` | Determines the interpretation of the Path matching, must be Prefix to serve assets. |
+| `ui.ingress.ingressClassName` | `nginx` | The name of an IngressClass cluster resource. |
+| `ui.ingress.tls` | `null` | Optional YAML tls configuration. |
+| `ui.ingress.annotations` | `null` | Annotations to apply to the user interface ingress. |
 
 ### Registry Server
 

--- a/charts/docker-registry-ui/templates/registry-ingress.yaml
+++ b/charts/docker-registry-ui/templates/registry-ingress.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.registry.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "docker-registry-ui.fullname" . }}-registry-server
+  labels:
+    app.kubernetes.io/component	: registry-server
+    {{- include "docker-registry-ui.labels" . | nindent 4 }}
+  {{- with .Values.registry.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.registry.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.registry.ingress.ingressClassName }}
+  {{- end -}}
+{{- if .Values.registry.ingress.tls }}
+  tls:
+{{ tpl (toYaml .Values.registry.ingress.tls) $ | indent 4 }}
+{{- end }}
+  rules:
+    - http:
+        paths:
+          - backend:
+              service:
+                name: {{ include "docker-registry-ui.fullname" . }}-registry-server
+                port:
+                  number: {{ .Values.registry.service.port }}
+            {{- if .Values.registry.ingress.path }}
+            path: {{ .Values.registry.ingress.path }}
+            {{- end }}
+            {{- if .Values.registry.ingress.pathType }}
+            pathType: {{ .Values.registry.ingress.pathType }}
+            {{- end }}
+      {{- if .Values.registry.ingress.host }}
+      host: {{ .Values.registry.ingress.host | quote }}
+      {{- end -}}
+{{- end }}

--- a/charts/docker-registry-ui/templates/ui-ingress.yaml
+++ b/charts/docker-registry-ui/templates/ui-ingress.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.ui.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "docker-registry-ui.fullname" . }}-user-interface
+  labels:
+    app.kubernetes.io/component	: user-interface
+    {{- include "docker-registry-ui.labels" . | nindent 4 }}
+  {{- with .Values.ui.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ui.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ui.ingress.ingressClassName }}
+  {{- end -}}
+{{- if .Values.ui.ingress.tls }}
+  tls:
+{{ tpl (toYaml .Values.ui.ingress.tls) $ | indent 4 }}
+{{- end }}
+  rules:
+    - http:
+        paths:
+          - backend:
+              service:
+                name: {{ include "docker-registry-ui.fullname" . }}-user-interface
+                port:
+                  number: {{ .Values.ui.service.port }}
+            {{- if .Values.ui.ingress.path }}
+            path: {{ .Values.ui.ingress.path }}
+            {{- end }}
+            {{- if .Values.ui.ingress.pathType }}
+            pathType: {{ .Values.ui.ingress.pathType }}
+            {{- end }}
+      {{- if .Values.ui.ingress.host }}
+      host: {{ .Values.ui.ingress.host | quote }}
+      {{- end -}}
+{{- end }}

--- a/charts/docker-registry-ui/values.yaml
+++ b/charts/docker-registry-ui/values.yaml
@@ -57,9 +57,9 @@ ui:
   # for server pods.
   affinity: {}
   # Annotations to apply to the user interface deployment.
-  annotations: null
+  annotations: {}
   # Optional YAML string that will be appended to the deployment spec.
-  additionalSpec: null
+  additionalSpec: {}
 
   service:
     # Type of service: `LoadBalancer`, `ClusterIP` or `NodePort`. If using `NodePort` service
@@ -72,9 +72,9 @@ ui:
     # If using a `NodePort` service type, you must specify the desired `nodePort` for each exposed port.
     nodePort: null
     # Annotations to apply to the user interface service.
-    annotations: null
+    annotations: {}
     # Optional YAML string that will be appended to the Service spec.
-    additionalSpec: null
+    additionalSpec: {}
 
   ingress:
     # Enable the ingress for the user interface.
@@ -88,9 +88,9 @@ ui:
     # The name of an IngressClass cluster resource.
     ingressClassName: nginx
     # TLS configuration
-    tls: null
+    tls: []
     # Annotations to apply to the user interface ingress.
-    annotations: null
+    annotations: {}
     # If you want a custom path, you can try this example:
     # path: /ui(/|$)(.*)
     # annotations:
@@ -117,9 +117,9 @@ registry:
   # for server pods.
   affinity: {}
   # Annotations to apply to the registry server deployment.
-  annotations: null
+  annotations: {}
   # Optional YAML string that will be appended to the deployment spec.
-  additionalSpec: null
+  additionalSpec: {}
 
   service:
     # Type of service: `LoadBalancer`, `ClusterIP` or `NodePort`. If using `NodePort` service
@@ -132,9 +132,9 @@ registry:
     # If using a `NodePort` service type, you must specify the desired `nodePort` for each exposed port.
     nodePort: null
     # Annotations to apply to the registry server service.
-    annotations: null
+    annotations: {}
     # Optional YAML string that will be appended to the Service spec.
-    additionalSpec: null
+    additionalSpec: {}
 
   ingress:
     # Enable the ingress for the registry server.
@@ -148,9 +148,9 @@ registry:
     # The name of an IngressClass cluster resource.
     ingressClassName: nginx
     # TLS configuration
-    tls: null
+    tls: []
     # Annotations to apply to the registry server ingress.
-    annotations: null
+    annotations: {}
     # If you want a custom path, you can try this example:
     # path: /api(/|$)(.*)
     # annotations:

--- a/charts/docker-registry-ui/values.yaml
+++ b/charts/docker-registry-ui/values.yaml
@@ -135,3 +135,23 @@ registry:
     annotations: null
     # Optional YAML string that will be appended to the Service spec.
     additionalSpec: null
+
+  ingress:
+    # Enable the ingress for the registry server.
+    enabled: false
+    # Fully qualified domain name of a network host.
+    host: null
+    # Path is matched against the path of an incoming request.
+    path: /v2/
+    # Determines the interpretation of the Path matching, must be Prefix to serve assets.
+    pathType: Prefix
+    # The name of an IngressClass cluster resource.
+    ingressClassName: nginx
+    # TLS configuration
+    tls: null
+    # Annotations to apply to the registry server ingress.
+    annotations: null
+    # If you want a custom path, you can try this example:
+    # path: /api(/|$)(.*)
+    # annotations:
+    #  nginx.ingress.kubernetes.io/rewrite-target: /$2

--- a/charts/docker-registry-ui/values.yaml
+++ b/charts/docker-registry-ui/values.yaml
@@ -77,13 +77,13 @@ ui:
     additionalSpec: null
 
   ingress:
-    # Enable the ingress
+    # Enable the ingress for the user interface.
     enabled: false
     # Fully qualified domain name of a network host.
     host: null
-    # Path is matched against the path of an incoming request
+    # Path is matched against the path of an incoming request.
     path: /
-    # Determines the interpretation of the Path matching, must be Prefix to serve assets
+    # Determines the interpretation of the Path matching, must be Prefix to serve assets.
     pathType: Prefix
     # The name of an IngressClass cluster resource.
     ingressClassName: nginx
@@ -91,7 +91,7 @@ ui:
     tls: null
     # Annotations to apply to the user interface ingress.
     annotations: null
-    # If you want a custom path, you can try this example
+    # If you want a custom path, you can try this example:
     # path: /ui(/|$)(.*)
     # annotations:
     #  nginx.ingress.kubernetes.io/rewrite-target: /$2

--- a/charts/docker-registry-ui/values.yaml
+++ b/charts/docker-registry-ui/values.yaml
@@ -76,6 +76,26 @@ ui:
     # Optional YAML string that will be appended to the Service spec.
     additionalSpec: null
 
+  ingress:
+    # Enable the ingress
+    enabled: false
+    # Fully qualified domain name of a network host.
+    host: null
+    # Path is matched against the path of an incoming request
+    path: /
+    # Determines the interpretation of the Path matching, must be Prefix to serve assets
+    pathType: Prefix
+    # The name of an IngressClass cluster resource.
+    ingressClassName: nginx
+    # TLS configuration
+    tls: null
+    # Annotations to apply to the user interface ingress.
+    annotations: null
+    # If you want a custom path, you can try this example
+    # path: /ui(/|$)(.*)
+    # annotations:
+    #  nginx.ingress.kubernetes.io/rewrite-target: /$2
+
 registry:
   # Enable the registry server.
   enabled: false


### PR DESCRIPTION
As requested by @masterkain  I added the support for kubernetes ingress

Interesting use case when the ui is on a custom pathname:
```yaml
  ingress:
    # Enable the ingress for the user interface.
    enabled: true
    # Fully qualified domain name of a network host.
    host: null
    # Path is matched against the path of an incoming request.
    path: /ui(/|$)(.*)
    # Determines the interpretation of the Path matching, must be Prefix to serve assets.
    pathType: Prefix
    # The name of an IngressClass cluster resource.
    ingressClassName: nginx
    # TLS configuration
    tls: null
    annotations:
      # This will rewrite the query to the backend and use only the last part (after ui) to serve assets.
      nginx.ingress.kubernetes.io/rewrite-target: /$2
```

fixes #1 