### PR TITLE
Adding Extra Env option for Registry

### DIFF
--- a/charts/docker-registry-ui/Chart.yaml
+++ b/charts/docker-registry-ui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: docker-registry-ui
-version: 0.4.0
+version: 0.4.1
 appVersion: "2.3.0"
 kubeVersion: ">=1.19.0-0"
 description: The simplest and most complete UI for your private registry

--- a/charts/docker-registry-ui/README.md
+++ b/charts/docker-registry-ui/README.md
@@ -85,6 +85,7 @@ helm upgrade --install docker-registry-ui joxit/docker-registry-ui
 | `registry.resources` | `{}` | The resource settings for registry server pod. |
 | `registry.nodeSelector` | `{}` | Optional YAML string to specify a nodeSelector config. |
 | `registry.tolerations` | `[]` | Optional YAML string to specify tolerations. |
+| `registry.extraEnv` | `[]` | Extra Environmental Variables for Registry. |
 | `registry.affinity` | `{}` | This value defines the [affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for server pods. |
 | `registry.annotations` | `{}` | Annotations to apply to the registry server deployment. |
 | `registry.additionalSpec` | `{}` | Optional YAML string that will be appended to the deployment spec. |

--- a/charts/docker-registry-ui/templates/registry-deployment.yaml
+++ b/charts/docker-registry-ui/templates/registry-deployment.yaml
@@ -36,6 +36,10 @@ spec:
           env:
             - name: REGISTRY_HTTP_ADDR
               value: {{ printf "%s:%d" "0.0.0.0" (.Values.registry.service.targetPort | int) }}
+            {{- range .Values.registry.extraEnv }}
+            - name: {{ .name }}
+              value: {{ .value }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.registry.service.targetPort }}

--- a/charts/docker-registry-ui/values.yaml
+++ b/charts/docker-registry-ui/values.yaml
@@ -123,6 +123,8 @@ registry:
   annotations: {}
   # Optional YAML string that will be appended to the deployment spec.
   additionalSpec: {}
+  # Extra Environmental Variables for Registry
+  extraEnv: []
 
   service:
     # Type of service: `LoadBalancer`, `ClusterIP` or `NodePort`. If using `NodePort` service


### PR DESCRIPTION
The goal of this PR is to allow users to add registry environment 


```
registry:
  enabled: true
  # https://docs.docker.com/registry/configuration/#override-specific-configuration-options
  extraEnv:
    - name: REGISTRY_DELETE_ENABLED
      value: true
  ```