### PR TITLE
Takeover clusterIP, loadBalancerIP and loadBalancerSourceRanges ui.service settings from docker-registry

### DIFF
--- a/charts/docker-registry-ui/README.md
+++ b/charts/docker-registry-ui/README.md
@@ -62,7 +62,10 @@ helm upgrade --install docker-registry-ui joxit/docker-registry-ui
 | `ui.service.type` | `ClusterIP` | Type of service: `LoadBalancer`, `ClusterIP` or `NodePort`. If using `NodePort` service type, you must set the desired `nodePorts` setting below. |
 | `ui.service.port` | `80` | Ports that will be exposed on the service |
 | `ui.service.targetPort` | `80` | The port to listhen on the container. If under 1024, the user must be root |
+| `ui.service.clusterIP`         | if `ui.service.type` is `ClusterIP` and this is non-empty, sets the cluster IP of the service | `nil`           |
 | `ui.service.nodePort` | `null` | If using a `NodePort` service type, you must specify the desired `nodePort` for each exposed port. |
+| `ui.service.loadBalancerIP`     | if `ui.service.type` is `LoadBalancer` and this is non-empty, sets the loadBalancerIP of the service | `nil`          |
+| `ui.service.loadBalancerSourceRanges`| if `ui.service.type` is `LoadBalancer` and this is non-empty, sets the loadBalancerSourceRanges of the service | `nil`           |
 | `ui.service.annotations` | `{}` | Annotations to apply to the user interface service. |
 | `ui.service.additionalSpec` | `{}` | Optional YAML string that will be appended to the Service spec. |
 | `ui.ingress.enable` | `false` | Enable the ingress for the user interface. |

--- a/charts/docker-registry-ui/templates/ui-service.yaml
+++ b/charts/docker-registry-ui/templates/ui-service.yaml
@@ -7,6 +7,15 @@ metadata:
     {{- include "docker-registry-ui.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.ui.service.type }}
+{{- if (and (eq .Values.ui.service.type "ClusterIP") (not (empty .Values.ui.service.clusterIP))) }}
+  clusterIP: {{ .Values.ui.service.clusterIP }}
+{{- end }}
+{{- if (and (eq .Values.ui.service.type "LoadBalancer") (not (empty .Values.ui.service.loadBalancerIP))) }}
+  loadBalancerIP: {{ .Values.ui.service.loadBalancerIP }}
+{{- end }}
+{{- if (and (eq .Values.ui.service.type "LoadBalancer") (not (empty .Values.ui.service.loadBalancerSourceRanges))) }}
+  loadBalancerSourceRanges: {{ .Values.ui.service.loadBalancerSourceRanges }}
+{{- end }}
   ports:
     - port: {{ .Values.ui.service.port }}
       targetPort: {{ .Values.ui.service.targetPort }}


### PR DESCRIPTION
Support of ui.service.clusterIP
Support of ui.service.loadBalancerIP
Support of ui.service.loadBalancerSourceRanges
