### PR TITLE
fix: removing "trim" function

### DIFF
--- a/charts/docker-registry-ui/templates/registry-deployment.yaml
+++ b/charts/docker-registry-ui/templates/registry-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         {{- include "docker-registry-ui.labels" . | nindent 8 }}
       {{- if .Values.registry.annotations }}
       annotations:
-        {{- toYaml .Values.registry.annotations | nindent 8 | trim }}
+        {{- toYaml .Values.registry.annotations | nindent 8 }}
       {{- end }}
     spec:
     {{- if ne (.Values.registry.imagePullSecrets | toString) "-" }}
@@ -58,15 +58,15 @@ spec:
           {{- end }}
       {{- with .Values.registry.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 | trim }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
     {{- with .Values.registry.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 | trim }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.registry.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 | trim }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- if not .Values.registry.runAsRoot }}
       securityContext:

--- a/charts/docker-registry-ui/templates/ui-deployment.yaml
+++ b/charts/docker-registry-ui/templates/ui-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         {{- include "docker-registry-ui.labels" . | nindent 8 }}
       {{- if .Values.ui.annotations }}
       annotations:
-        {{- toYaml .Values.ui.annotations | nindent 8 | trim }}
+        {{- toYaml .Values.ui.annotations | nindent 8 }}
       {{- end }}
     spec:
     {{- if ne (.Values.ui.imagePullSecrets | toString) "-" }}
@@ -108,15 +108,15 @@ spec:
             {{- toYaml .Values.ui.resources | nindent 12 }}
       {{- with .Values.ui.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 | trim }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
     {{- with .Values.ui.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 | trim }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.ui.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 | trim }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- if not .Values.ui.runAsRoot }}
       securityContext:


### PR DESCRIPTION
## Issue ##
When using **Helm V3**, if we set array on key that convert with **toYaml** function, it's produce mapping value not allowed on context error

## Reproduce ##
- Using from `values.yaml`
- Change, for example, `tolerations` with some values:
```
...
tolerations:
   - key: "some-key"
      operator: "Exists"
      effect: "NoSchedule"
...
```
- Run `helm install` command
- Error triggered

## Actual ##
Mapping values are not allowed on context error showed

## Expected ##
No error on run

---
## Additional Proof ##
<img width="1440" alt="image" src="https://github.com/Joxit/helm-charts/assets/2128638/5f6a6ed3-a52d-41e5-8a16-6ac2e56ad95c">

---
This will fix #11 