### PR TITLE
Fix Selectors and add PodDisruptionBudget

### DIFF
--- a/charts/docker-registry-ui/Chart.yaml
+++ b/charts/docker-registry-ui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: docker-registry-ui
-version: 1.1.4
+version: 1.2.0
 appVersion: "2.6.0"
 kubeVersion: ">=1.19.0-0"
 description: The simplest and most complete UI for your private registry

--- a/charts/docker-registry-ui/README.md
+++ b/charts/docker-registry-ui/README.md
@@ -88,6 +88,7 @@ helm upgrade --install docker-registry-ui joxit/docker-registry-ui
 | `ui.resources` | `{}` | The resource settings for user interface pod. |
 | `ui.nodeSelector` | `{}` | Optional YAML string to specify a nodeSelector config. |
 | `ui.tolerations` | `[]` | Optional YAML string to specify tolerations. |
+| `ui.podDisruptionBudget` | `[]` | Optional YAML string to specify PodDisruptionBudget - needs either `minAvailable` or `maxUnavailable`. |
 | `ui.affinity` | `{}` | This value defines the [affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for server pods. |
 | `ui.annotations` | `{}` | Annotations to apply to the user interface deployment. |
 | `ui.additionalSpec` | `{}` | Optional YAML string that will be appended to the deployment spec. |
@@ -117,6 +118,7 @@ helm upgrade --install docker-registry-ui joxit/docker-registry-ui
 | `registry.resources` | `{}` | The resource settings for registry server pod. |
 | `registry.nodeSelector` | `{}` | Optional YAML string to specify a nodeSelector config. |
 | `registry.tolerations` | `[]` | Optional YAML string to specify tolerations. |
+| `registry.podDisruptionBudget` | `[]` | Optional YAML string to specify PodDisruptionBudget - needs either `minAvailable` or `maxUnavailable`. |
 | `registry.affinity` | `{}` | This value defines the [affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for server pods. |
 | `registry.annotations` | `{}` | Annotations to apply to the registry server deployment. |
 | `registry.additionalSpec` | `{}` | Optional YAML string that will be appended to the deployment spec. |

--- a/charts/docker-registry-ui/templates/_helpers.tpl
+++ b/charts/docker-registry-ui/templates/_helpers.tpl
@@ -41,3 +41,11 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 helm.sh/chart: {{ include "docker-registry-ui.chart" . }}
 {{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "docker-registry-ui.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "docker-registry-ui.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/docker-registry-ui/templates/registry-deployment.yaml
+++ b/charts/docker-registry-ui/templates/registry-deployment.yaml
@@ -11,7 +11,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component	: registry-server
-      {{- include "docker-registry-ui.labels" . | nindent 6 }}
+      {{- include "docker-registry-ui.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:

--- a/charts/docker-registry-ui/templates/registry-pdb.yaml
+++ b/charts/docker-registry-ui/templates/registry-pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.registry.podDisruptionBudget }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "docker-registry-ui.fullname" . }}-registry-server
+  labels:
+    app.kubernetes.io/component: registry-server
+    {{- include "docker-registry-ui.labels" . | nindent 4 }}
+
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: registry-server
+      {{- include "docker-registry-ui.selectorLabels" . | nindent 6 }}
+  {{ toYaml .Values.registry.podDisruptionBudget }}
+{{- end }}
+

--- a/charts/docker-registry-ui/templates/registry-service.yaml
+++ b/charts/docker-registry-ui/templates/registry-service.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   selector:
     app.kubernetes.io/component	: registry-server
-    {{- include "docker-registry-ui.labels" . | nindent 4 }}
+    {{- include "docker-registry-ui.selectorLabels" . | nindent 4 }}
   type: {{ .Values.registry.service.type }}
   ports:
     - port: {{ .Values.registry.service.port }}

--- a/charts/docker-registry-ui/templates/ui-deployment.yaml
+++ b/charts/docker-registry-ui/templates/ui-deployment.yaml
@@ -14,7 +14,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component	: user-interface
-      {{- include "docker-registry-ui.labels" . | nindent 6 }}
+      {{- include "docker-registry-ui.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:

--- a/charts/docker-registry-ui/templates/ui-pdb.yaml
+++ b/charts/docker-registry-ui/templates/ui-pdb.yaml
@@ -1,5 +1,4 @@
-{{- if gt .Values.ui.replicas 1.0 }}
-
+{{- if .Values.ui.podDisruptionBudget }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -9,10 +8,10 @@ metadata:
     {{- include "docker-registry-ui.labels" . | nindent 4 }}
 
 spec:
-  minAvailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/component: user-interface
       {{- include "docker-registry-ui.selectorLabels" . | nindent 6 }}
+  {{ toYaml .Values.ui.podDisruptionBudget }}
 {{- end }}
 

--- a/charts/docker-registry-ui/templates/ui-pdb.yaml
+++ b/charts/docker-registry-ui/templates/ui-pdb.yaml
@@ -1,0 +1,18 @@
+{{- if gt .Values.ui.replicas 1.0 }}
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "docker-registry-ui.fullname" . }}-user-interface
+  labels:
+    app.kubernetes.io/component: user-interface
+    {{- include "docker-registry-ui.labels" . | nindent 4 }}
+
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: user-interface
+      {{- include "docker-registry-ui.selectorLabels" . | nindent 6 }}
+{{- end }}
+

--- a/charts/docker-registry-ui/templates/ui-service.yaml
+++ b/charts/docker-registry-ui/templates/ui-service.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   selector:
     app.kubernetes.io/component	: user-interface
-    {{- include "docker-registry-ui.labels" . | nindent 4 }}
+    {{- include "docker-registry-ui.selectorLabels" . | nindent 4 }}
   type: {{ .Values.ui.service.type }}
   ports:
     - port: {{ .Values.ui.service.port }}


### PR DESCRIPTION
Hi - 2 changes:

Fixup Deployment and Service selectors to not include the app version. Before:

app.kubernetes.io/component=registry-server,app.kubernetes.io/instance=docker-registry-ui,app.kubernetes.io/managed-by=Helm,app.kubernetes.io/name=docker-registry-ui,app.kubernetes.io/version=2.6.0,helm.sh/chart=docker-registry-ui-helm


After:

 app.kubernetes.io/component=registry-server,app.kubernetes.io/instance=docker-registry-ui,app.kubernetes.io/name=docker-registry-ui

The Selectors are immutable, so Kubernetes will refuse to apply any updates if the Helm chart's appVersion gets changed. This change fixes that, at the cost of one last breaking change.

Also add PodDisruptionBudget for the UI pods, so Kubernetes can smoothly move pods around without service interruption (node maintenance or descheduler activity). This has no effect when the deployment has only one pod.